### PR TITLE
Add metadata to biom table

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,9 @@ Usage examples
 
     $ kraken-biom S1.txt S2.txt --max C --min G
 
+4. Basic usage with default parameters and metadata::
+    $ kraken-biom S1.txt S2.txt -m metadata.tsv
+
 
 Program arguments
 -----------------
@@ -123,6 +126,14 @@ optional arguments::
                             to a different format using the --fmt option. The
                             output can also be gzipped using the --gzip option.
                             Default path is: ./table.biom
+     -m METADATA, --metadata METADATA
+                            Path to the sample metadata file. This should be in
+                            TSV format. The first column should be the sample id.
+                            This is the same name as the input files. If no
+                            metadata is given, basic metadata is added to help
+                            when importing the biom file on sites like phinch
+                            (http://phinch.org/index.html).
+
       --fmt {hdf5,json,tsv}
                             Set the output format of the BIOM table. Default is
                             HDF5.

--- a/README.rst
+++ b/README.rst
@@ -100,9 +100,10 @@ Usage examples
 
     $ kraken-biom S1.txt S2.txt --max C --min G
 
-4. Basic usage with default parameters and metadata::
-    $ kraken-biom S1.txt S2.txt -m metadata.tsv
+5. Basic usage with default parameters and metadata::
 
+    $ kraken-biom S1.txt S2.txt -m metadata.tsv
+This produces a compressed BIOM 2.1 file: table.biom
 
 Program arguments
 -----------------

--- a/test/test_biom_create.py
+++ b/test/test_biom_create.py
@@ -183,8 +183,11 @@ class kraken_biom_Test(unittest.TestCase):
         self.sample_counts["A"] = countsA
         self.sample_counts["B"] = countsB
 
+        # Make the dummy metadata for the samples.
+        self.metadata =kb.process_metadata(self.sample_counts ,None)
+
         # create the BIOM table from the sample counts and taxa
-        self.biomT = kb.create_biom_table(self.sample_counts, self.taxa)
+        self.biomT = kb.create_biom_table(self.sample_counts, self.taxa,self.metadata)
 
     def test_sample_ids(self):
         biom_sample_ids = self.biomT.ids(axis="sample")
@@ -220,7 +223,12 @@ class kraken_biom_Test(unittest.TestCase):
         self.assertTrue(all([self.biomT.get_value_by_ids(otu_id, "B") 
                              == countsB[otu_id] for otu_id in countsB]))
 
+    def test_metadata(self):
+        metadata = self.biomT.metadata()
 
+        self.assertEqual(len(metadata), 2)
+        self.assertEqual( dict(self.biomT.metadata("A"))['Id'],'A')
+        self.assertEqual( dict(self.biomT.metadata("B"))['Id'],'B')
 
     def tearDown(self):
         pass


### PR DESCRIPTION
## Problem
While working with the output BIOMs form this great tool I found out that not all tools like it when a BIOM file has no metadata. 

## fix
To fix this problem I've added the option for the user to add tsv metadata file to the BIOM file. These files can be [Qiime](http://qiime.org/documentation/file_formats.html#mapping-file-overview) style mapping files.

With `-m` you can tell which metadata file should be added. The first column in the metadata file needs to be the sample names (same as the imported files). 
When no metadata file is given as input dummy metadata is made. This is the sample name.
`{"Id": sample name}`  This way there is always metadata in the BIOM file. 

## changes made

- Added `-m/--metadata` to argparser
- Unittest for dummy metadata
- Import pandas for reading tsv file
- Add dummy metadata if none is added
- bumped version number to 1.1.1